### PR TITLE
修复在菜单mobile模式下不能正确切换问题

### DIFF
--- a/css/layuimini.css
+++ b/css/layuimini.css
@@ -825,5 +825,6 @@
 }
 .popup-tips .layui-nav-tree{
     width: 150px;
+    border-radius: 10px;
 }
 

--- a/js/lay-module/layuimini/miniAdmin.js
+++ b/js/lay-module/layuimini/miniAdmin.js
@@ -283,7 +283,7 @@ layui.define(["jquery", "miniMenu", "element","miniTab", "miniTheme"], function 
                     tips = $(this).prop("innerHTML"),
                     isShow = $('.layuimini-tool i').attr('data-side-fold');
                 if (isShow == 0 && tips) {
-                    tips = "<ul class='layui-nav layui-nav-tree layui-this'><li class='layui-nav-item '>"+tips+"</li></ul>" ;
+                    tips = "<ul class='layui-nav layui-nav-tree layui-this'><li class='layui-nav-item layui-nav-itemed'>"+tips+"</li></ul>" ;
                     window.openTips = layer.tips(tips, $(this), {
                         tips: [2, '#2f4056'],
                         time: 300000,

--- a/js/lay-module/layuimini/miniMenu.js
+++ b/js/lay-module/layuimini/miniMenu.js
@@ -56,7 +56,7 @@ layui.define(["element","laytpl" ,"jquery"], function (exports) {
         compileMenu: function(menu,isSub){
             var menuHtml = '<li {{#if( d.menu){ }}  data-menu="{{d.menu}}" {{#}}} class="layui-nav-item menu-li {{d.className}}"  {{#if( d.id){ }}  id="{{d.id}}" {{#}}}> <a {{#if( d.href){ }} layuimini-href="{{d.href}}" {{#}}} {{#if( d.target){ }}  target="{{d.target}}" {{#}}} href="javascript:;">{{#if( d.icon){ }}  <i class="{{d.icon}}"></i> {{#}}} <span class="layui-left-nav">{{d.title}}</span></a>  {{# if(d.children){}} {{d.children}} {{#}}} </li>' ;
             if(isSub){
-                menuHtml = '<dd class="menu-dd {{d.className }}"> <a href="javascript:;"  {{#if(( !d.child || !d.child.length ) && d.href){ }} layuimini-href="{{d.href}}" {{#}}} {{#if( d.target){ }}  target="{{d.target}}" {{#}}}> {{#if( d.icon){ }}  <i class="{{d.icon}}"></i> {{#}}} <span class="layui-left-nav"> {{d.title}}</span></a> {{# if(d.children){}} {{d.children}} {{#}}}</dd>'
+                menuHtml = '<dd class="menu-dd {{d.className }}"> <a href="javascript:;"  {{#if( d.menu){ }}  data-menu="{{d.menu}}" {{#}}} {{#if( d.id){ }}  id="{{d.id}}" {{#}}} {{#if(( !d.child || !d.child.length ) && d.href){ }} layuimini-href="{{d.href}}" {{#}}} {{#if( d.target){ }}  target="{{d.target}}" {{#}}}> {{#if( d.icon){ }}  <i class="{{d.icon}}"></i> {{#}}} <span class="layui-left-nav"> {{d.title}}</span></a> {{# if(d.children){}} {{d.children}} {{#}}}</dd>'
             }
             return laytpl(menuHtml).render(menu);
         },
@@ -142,7 +142,7 @@ layui.define(["element","laytpl" ,"jquery"], function (exports) {
                     parentMenuId:menu,
                     leftMenuCheckDefault:leftMenuCheckDefault
                 });
-                headerMobileMenuHtml +=me.compileMenu({ id:id,menu:menu,icon:val.icon, title:val.title, },true);
+                headerMobileMenuHtml +=me.compileMenu({ id:id,menu:menu,id:id,icon:val.icon, title:val.title, },true);
                 headerMenuCheckDefault = "";
                 leftMenuCheckDefault = "layui-hide" ;
                 return topMenuItemHtml ;


### PR DESCRIPTION
1. 菜单mobile模式下不能正确切换问题
1. 优化弹出菜单，默认展开第一层
1. 优化弹出菜单，添加圆角